### PR TITLE
Support base-4.14.0.0

### DIFF
--- a/regex-pcre.cabal
+++ b/regex-pcre.cabal
@@ -54,7 +54,7 @@ library
       FlexibleInstances
 
   build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 4.14
+               , base       >= 4.3 && < 4.15
                , containers >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 0.11
                , array      >= 0.3 && < 0.6


### PR DESCRIPTION
PR to support newest base version (ghc-8.10.1 comes with base-4.14.0.0).
