### PR TITLE
v1.0.0.0: Migrate to libpcre2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 See also http://pvp.haskell.org/faq
 
+## 1.0.0.0
+
+- Migrate from the obsolete pcre3 library to the new (confusingly-named) pcre2 one
+
 ## 0.95.0.0 revision 6
 
 - Allow `containers-0.7`

--- a/regex-pcre.cabal
+++ b/regex-pcre.cabal
@@ -1,7 +1,6 @@
 Cabal-Version:          1.12
 Name:                   regex-pcre
-Version:                0.95.0.0
-x-revision:             6
+Version:                1.0.0.0
 
 build-type:             Simple
 license:                BSD3
@@ -40,7 +39,7 @@ tested-with:
 flag pkg-config
   default:     True
   manual:      True
-  description: Use @pkg-config(1)@ to locate foreign @pcre@ library.
+  description: Use @pkg-config(1)@ to locate foreign @pcre2@ library.
 
 source-repository head
   type:     git
@@ -49,7 +48,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/haskell-hvr/regex-pcre.git
-  tag:      v0.95.0.0-r6
+  tag:      v1.0.0.0
 
 library
   hs-source-dirs: src
@@ -85,11 +84,28 @@ library
       build-depends: fail == 4.9.*
 
   if flag(pkg-config)
-    pkgconfig-depends: libpcre
+    pkgconfig-depends: libpcre2-8
   else
-    extra-libraries: pcre
+    extra-libraries: pcre2-8
 
   ghc-options:
     -O2
     -Wall -fno-warn-unused-imports
     -- -Wcompat -- options cannot be changed in a revision
+
+test-suite regex-pcre-test
+  default-language: Haskell2010
+  ghc-options:      -Wall
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:    base >= 4.3 && < 5
+                  , bytestring >= 0.9 && < 0.13
+                  , HUnit >= 1.6 && < 1.7
+                  , regex-pcre
+                  , utf8-string >= 1.0 && < 1.1
+
+  if flag(pkg-config)
+    pkgconfig-depends: libpcre2-8
+  else
+    extra-libraries: pcre2-8

--- a/src/Text/Regex/PCRE.hs
+++ b/src/Text/Regex/PCRE.hs
@@ -4,25 +4,22 @@ expressions.  If you import this along with other backends, then
 you should do so with qualified imports, perhaps renamed for
 convenience.
 
-Using the provided 'CompOption' and 'ExecOption' values and if
-'configUTF8' is True, then you might be able to send UTF8 encoded
-ByteStrings to PCRE and get sensible results.  This is currently
-untested.
+From version 1.0.0.0, this library uses the newer libpcre2, which
+supports UTF8-encoded strings by default.  As such, 'configUTF8'
+now always returns True.
 
-The regular expression can be provided as a 'ByteString', but it will
-be copied and a NUL byte appended to make a 'CString' unless such a
-byte is already present.  Thus the regular expression cannot contain
-an explicit NUL byte. The search string is passed as a 'CStringLen'
-and may contain NUL bytes and does not need to end in a NUL
-byte. 'ByteString's are searched in place (via unsafeUseAsCStringLen).
+The regular expression can be provided as a 'ByteString'.  The
+regular expression and search string are passed as 'CStringLen's
+and may contain NUL bytes and do not need to end in a NUL byte.
+'ByteString's are searched in place (via unsafeUseAsCStringLen).
 
-A 'String' will be converted into a 'CString' or 'CStringLen' for
-processing.  Doing this repeatedly will be very inefficient.
+A 'String' will be converted into a 'CStringLen' for processing.
+Doing this repeatedly will be very inefficient.
 
 The "Text.Regex.PCRE.String", "Text.Regex.PCRE.ByteString", and
-"Text.Regex.PCRE.Wrap" modules provides both the high level interface
+"Text.Regex.PCRE.Wrap" modules provide both the high-level interface
 exported by this module and medium- and low-level interfaces that
-returns error using Either structures.
+return errors using 'Either' structures.
 -}
 {- Copyright   :  (c) Chris Kuklewicz 2007 -}
 module Text.Regex.PCRE(getVersion_Text_Regex_PCRE
@@ -32,14 +29,21 @@ module Text.Regex.PCRE(getVersion_Text_Regex_PCRE
 
 import Prelude hiding (fail)
 
-import Text.Regex.PCRE.Wrap(Regex, CompOption(CompOption), ExecOption(ExecOption), (=~), (=~~),
+import Text.Regex.PCRE.Wrap(
+  Regex, CompOption(CompOption), MatchOption(MatchOption),
+  (=~), (=~~),
   unusedOffset, getNumSubs, configUTF8, getVersion,
-  compBlank, compAnchored, compAutoCallout, compCaseless,
-  compDollarEndOnly, compDotAll, compExtended, compExtra,
-  compFirstLine, compMultiline, compNoAutoCapture, compUngreedy,
-  compUTF8, compNoUTF8Check,
-  execBlank, execAnchored, execNotBOL, execNotEOL, execNotEmpty,
-  execNoUTF8Check, execPartial)
+  compBlank, compAnchored, compEndAnchored, compAllowEmptyClass,
+  compAltBSUX, compAltExtendedClass, compAltVerbnames,
+  compAutoCallout, compCaseless, compDollarEndOnly, compDotAll,
+  compDupNames, compExtended, compExtendedMore, compFirstLine,
+  compLiteral, compMatchUnsetBackref, compMultiline,
+  compNeverBackslashC, compNoAutoCapture, compNoAutoPossess,
+  compNoDotstarAnchor, compNoUTFCheck, compUngreedy, compUTF,
+  matchBlank, matchAnchored, matchCopyMatchedSubject,
+  matchDisableRecurseLoopCheck, matchEndAnchored, matchNotBOL,
+  matchNotEOL, matchNotEmpty, matchNotEmptyAtStart,
+  matchNoUTFCheck, matchPartialHard, matchPartialSoft)
 import Text.Regex.PCRE.String()
 import Text.Regex.PCRE.Sequence()
 import Text.Regex.PCRE.ByteString()

--- a/src/Text/Regex/PCRE/Wrap.hsc
+++ b/src/Text/Regex/PCRE/Wrap.hsc
@@ -12,7 +12,8 @@ module Text.Regex.PCRE.Wrap(
   -- ** High-level interface
   Regex,
   CompOption(CompOption),
-  ExecOption(ExecOption),
+--   ExecOption(ExecOption), -- obsoleted in v1.0.0.0 (pcre2), use MatchOption instead
+  MatchOption(MatchOption),
   (=~),
   (=~~),
 
@@ -29,42 +30,62 @@ module Text.Regex.PCRE.Wrap(
 
   -- ** Miscellaneous
   getVersion,
-  configUTF8,
+  configUTF8, -- deprecated in v1.0.0.0 (pcre2), UFT8 is always supported
   getNumSubs,
   unusedOffset,
 
   -- ** CompOption values
   compBlank,
   compAnchored,
+  compEndAnchored, -- new in v1.0.0.0 (pcre2)
+  compAllowEmptyClass, -- new in v1.0.0.0 (pcre2)
+  compAltBSUX, -- new in v1.0.0.0 (pcre2)
+  compAltExtendedClass, -- new in v1.0.0.0 (pcre2)
+  compAltVerbnames, -- new in v1.0.0.0 (pcre2)
   compAutoCallout,
   compCaseless,
   compDollarEndOnly,
   compDotAll,
+  compDupNames, -- new in v1.0.0.0 (pcre2)
   compExtended,
-  compExtra,
+  compExtendedMore, -- new in v1.0.0.0 (pcre2)
+--  compExtra, -- obsoleted in v1.0.0.0, pcre2 is always strict in this way
   compFirstLine,
+  compLiteral, -- new in v1.0.0.0 (pcre2)
+  compMatchUnsetBackref, -- new in v1.0.0.0 (pcre2)
   compMultiline,
+  compNeverBackslashC, -- new in v1.0.0.0 (pcre2)
   compNoAutoCapture,
+  compNoAutoPossess, -- new in v1.0.0.0 (pcre2)
+  compNoDotstarAnchor, -- new in v1.0.0.0 (pcre2)
+--   compNoUTF8Check, -- obsoleted in v1.0.0.0 (pcre2), use compNoUTFCheck
+  compNoUTFCheck,
   compUngreedy,
-  compUTF8,
-  compNoUTF8Check,
+--   compUTF8, -- obsoleted in v1.0.0.0 (pcre2), use compUTF
+  compUTF,
 
-  -- ** ExecOption values
-  execBlank,
-  execAnchored,
-  execNotBOL,
-  execNotEOL,
-  execNotEmpty,
-  execNoUTF8Check,
-  execPartial,
+  -- ** MatchOption values, new to v1.0.0.0 (pcre2), replacing the obsolete ExecOptions
+  matchBlank,
+  matchAnchored,
+  matchCopyMatchedSubject, -- new in v1.0.0.0 (pcre2)
+  matchDisableRecurseLoopCheck, -- new in v1.0.0.0 (pcre2)
+  matchEndAnchored, -- new in v1.0.0.0 (pcre2)
+  matchNotBOL,
+  matchNotEOL,
+  matchNotEmpty,
+  matchNotEmptyAtStart, -- new in v1.0.0.0 (pcre2)
+  matchNoUTFCheck, -- equivalent to the obsolete execNoUTF8Check
+  matchPartialHard,
+  matchPartialSoft, -- equivalent to the obsolete execPartial
 
   -- ** ReturnCode values
   retOk,
   retNoMatch,
+  retPartial, -- new in v1.0.0.0 (pcre2)
   retNull,
   retBadOption,
   retBadMagic,
-  retUnknownNode,
+  retUnknownNode, -- deprecated in v1.0.0.0 (pcre2), no longer ever returned
   retNoMemory,
   retNoSubstring
   ) where
@@ -72,19 +93,21 @@ module Text.Regex.PCRE.Wrap(
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(fail))
 
+import Control.Exception(bracket)
 import Control.Monad(when)
 import Data.Array(Array,accumArray)
 import Data.Bits(Bits((.|.))) -- ((.&.),(.|.),complement))
+import Data.Word(Word32)
 import System.IO.Unsafe(unsafePerformIO)
 import Foreign(Ptr,ForeignPtr,FinalizerPtr -- ,FunPtr
               ,alloca,allocaBytes,nullPtr
+              ,mallocBytes,free
               ,peek,peekElemOff
               ,newForeignPtr,withForeignPtr)
-import Foreign.C(CChar)
 #if __GLASGOW_HASKELL__ >= 703
-import Foreign.C(CInt(CInt))
+import Foreign.C(CInt(CInt),CSize(CSize))
 #else
-import Foreign.C(CInt)
+import Foreign.C(CInt,CSize)
 #endif
 import Foreign.C.String(CString,CStringLen,peekCString)
 import Text.Regex.Base.RegexLike(RegexOptions(..),RegexMaker(..),RegexContext(..),MatchArray,MatchOffset)
@@ -96,25 +119,28 @@ import Text.Regex.Base.RegexLike(RegexOptions(..),RegexMaker(..),RegexContext(..
 getVersion :: Maybe String
 
 type PCRE = ()
+type CompContext = ()
+type MatchContext = ()
+type MatchData = ()
 type StartOffset = MatchOffset
 type EndOffset = MatchOffset
 type WrapError = (ReturnCode,String)
 
-newtype CompOption = CompOption CInt deriving (Eq,Show,Num,Bits)
-newtype ExecOption = ExecOption CInt deriving (Eq,Show,Num,Bits)
-newtype ReturnCode = ReturnCode CInt deriving (Eq,Show)
+newtype CompOption  = CompOption  Word32 deriving (Eq,Show,Num,Bits)
+newtype MatchOption = MatchOption Word32 deriving (Eq,Show,Num,Bits)
+newtype ReturnCode  = ReturnCode  CInt deriving (Eq,Show)
 
 -- | A compiled regular expression
-data Regex = Regex (ForeignPtr PCRE) CompOption ExecOption
+data Regex = Regex (ForeignPtr PCRE) CompOption MatchOption Int
 
 compBlank :: CompOption
-execBlank :: ExecOption
+matchBlank :: MatchOption
 unusedOffset :: MatchOffset
 retOk :: ReturnCode
 
-wrapCompile :: CompOption -- ^ Flags (summed together)
-            -> ExecOption -- ^ Flags (summed together)
-            -> CString  -- ^ The regular expression to compile
+wrapCompile :: CompOption  -- ^ Flags (summed together)
+            -> MatchOption -- ^ Flags (summed together)
+            -> CStringLen  -- ^ The regular expression to compile
             -> IO (Either (MatchOffset,String) Regex) -- ^ Returns: an error offset and string or the compiled regular expression
 wrapTest :: StartOffset -- ^ Starting index in CStringLen
          -> Regex       -- ^ Compiled regular expression
@@ -136,163 +162,159 @@ getNumSubs :: Regex -> Int
 {-# NOINLINE configUTF8 #-}
 configUTF8 :: Bool
 
-(=~)  :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target)
+(=~)  :: (RegexMaker Regex CompOption MatchOption source,RegexContext Regex source1 target)
       => source1 -> source -> target
-(=~~) :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target,MonadFail m)
+(=~~) :: (RegexMaker Regex CompOption MatchOption source,RegexContext Regex source1 target,MonadFail m)
       => source1 -> source -> m target
 
 #include <sys/types.h>
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
-instance RegexOptions Regex CompOption ExecOption where
+instance RegexOptions Regex CompOption MatchOption where
   blankCompOpt = compBlank
-  blankExecOpt = execBlank
+  blankExecOpt = matchBlank
   defaultCompOpt = compMultiline
-  defaultExecOpt = execBlank
-  setExecOpts e' (Regex r c _) = Regex r c e'
-  getExecOpts (Regex _ _ e) = e
+  defaultExecOpt = matchBlank
+  setExecOpts e' (Regex r c _ n) = Regex r c e' n
+  getExecOpts (Regex _ _ e _) = e
 
--- (=~) :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target) => source1 -> source -> target
+-- (=~) :: (RegexMaker Regex CompOption MatchOption source,RegexContext Regex source1 target) => source1 -> source -> target
 (=~) x r = let q :: Regex
                q = makeRegex r
            in match q x
 
--- (=~~) ::(RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target,MonadFail m) => source1 -> source -> m target
+-- (=~~) ::(RegexMaker Regex CompOption MatchOption source,RegexContext Regex source1 target,MonadFail m) => source1 -> source -> m target
 (=~~) x r = do (q :: Regex) <-  makeRegexM r
                matchM q x
 
-type PCRE_Extra = ()
-
-fi :: (Integral i,Num n ) => i -> n
+fi :: (Integral i,Num n) => i -> n
 fi x = fromIntegral x
 
 compBlank = CompOption 0
-execBlank = ExecOption 0
+matchBlank = MatchOption 0
 unusedOffset = (-1)
 retOk = ReturnCode 0
 
-retNeededMoreSpace :: ReturnCode
-retNeededMoreSpace = ReturnCode 0
+-- retNeededMoreSpace :: ReturnCode
+-- retNeededMoreSpace = ReturnCode 0
 
-newtype InfoWhat = InfoWhat CInt deriving (Eq,Show)
-newtype ConfigWhat = ConfigWhat CInt deriving (Eq,Show)
+newtype InfoWhat   = InfoWhat   Word32 deriving (Eq,Show)
+newtype ConfigWhat = ConfigWhat Word32 deriving (Eq,Show)
 
 nullTest' :: Ptr a -> String -> IO (Either (MatchOffset,String) b) -> IO (Either (MatchOffset,String) b)
 {-# INLINE nullTest' #-}
 nullTest' ptr msg io = do
   if nullPtr == ptr
-    then return (Left (0,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg)) 
+    then return (Left (0,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg))
     else io
 
 nullTest :: Ptr a -> String -> IO (Either WrapError b) -> IO (Either WrapError b)
 {-# INLINE nullTest #-}
 nullTest ptr msg io = do
   if nullPtr == ptr
-    then return (Left (retOk,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg)) 
+    then return (Left (retOk,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg))
     else io
+
+getErrMsg :: CInt -> IO String
+{-# INLINE getErrMsg #-}
+getErrMsg errnum = do
+  errstr <- mallocBytes 1024
+  if nullPtr == errstr
+    then return "Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap.getErrMsg errstr"
+    else do
+      _ <- c_pcre2_get_error_message errnum errstr 1024
+      errstr' <- peekCString errstr
+      free errstr
+      return errstr'
 
 wrapRC :: ReturnCode -> IO (Either WrapError b)
 {-# INLINE wrapRC #-}
-wrapRC r = return (Left (r,"Error in Text.Regex.PCRE.Wrap: "++show r))
+wrapRC errnum@(ReturnCode errnum') = do
+  errstr <- getErrMsg errnum'
+  return (Left (errnum,"Error in Text.Regex.PCRE.Wrap: "++errstr))
 
 -- | Compiles a regular expression
-wrapCompile flags e pattern = do
+wrapCompile flags e (pattern,len) = do
  nullTest' pattern "wrapCompile pattern" $ do
   alloca $ \errOffset -> alloca $ \errPtr -> do
    nullTest' errPtr "wrapCompile errPtr" $ do
-    pcre_ptr <- c_pcre_compile pattern flags errPtr errOffset nullPtr
+    pcre_ptr <- c_pcre2_compile pattern (fi len) flags errPtr errOffset nullPtr
     if pcre_ptr == nullPtr
       then do
-        -- No need to use c_ptr_free in the error case (e.g. pcredemo.c)
+        -- No need to use c_pcre2_code_free in the error case (e.g. pcredemo.c)
         offset <- peek errOffset
-        string <- peekCString =<< peek errPtr
-        return (Left (fi offset,string))
-      else do regex <- newForeignPtr c_ptr_free pcre_ptr
-              return . Right $ Regex regex flags e
+        errstr <- getErrMsg =<< peek errPtr
+        return (Left (fi offset, errstr))
+      else do
+        alloca $ \st -> do -- (st :: Ptr CInt)
+          when (st == nullPtr) (fail "Text.Regex.PCRE.Wrap.wrapCompile could not allocate a CInt for the capture count.")
+          ok0 <- c_pcre2_pattern_info pcre_ptr pcre2InfoCapturecount st
+          when (ok0 /= 0) (fail $ "Impossible/fatal: Haskell package regex-pcre error in Text.Posix.PCRE.Wrap.getNumSubs' of ok0 /= 0.  ok0 is from pcre2_pattern_info c-function which returned  "++show ok0)
+          n <- peek st
+          regex <- newForeignPtr c_pcre2_code_free pcre_ptr
+          return . Right $ Regex regex flags e n
 
-getNumSubs (Regex pcre_fptr _ _) = fi . unsafePerformIO $ withForeignPtr pcre_fptr getNumSubs'
+getNumSubs (Regex _ _ _ n) = n
 
-getNumSubs' :: Ptr PCRE -> IO CInt
-{-# INLINE getNumSubs' #-}
-getNumSubs' pcre_ptr =
-  alloca $ \st -> do -- (st :: Ptr CInt)
-    when (st == nullPtr) (fail "Text.Regex.PCRE.Wrap.getNumSubs' could not allocate a CInt!!!")
-    ok0 <- c_pcre_fullinfo pcre_ptr nullPtr pcreInfoCapturecount st
-    when (ok0 /= 0) (fail $ "Impossible/fatal: Haskell package regex-pcre error in Text.Posix.PCRE.Wrap.getNumSubs' of ok0 /= 0.  ok0 is from pcre_fullinfo c-function which returned  "++show ok0)
-    peek st
+withDataPtr :: IO (Ptr MatchData) -> String -> (Ptr MatchData -> IO (Either WrapError a)) -> IO (Either WrapError a)
+withDataPtr data_create jobname job = bracket data_create c_pcre2_match_data_free job'
+  where
+    job' dataPtr = nullTest dataPtr (jobname++" dataPtr") (job dataPtr)
 
-wrapTest startOffset (Regex pcre_fptr _ flags) (cstr,len) = do
+wrapTest startOffset (Regex pcre_fptr _ flags _) (cstr,len) = do
  nullTest cstr "wrapTest cstr" $ do
   withForeignPtr pcre_fptr $ \pcre_ptr -> do
-    r@(ReturnCode r') <- c_pcre_exec pcre_ptr nullPtr cstr (fi len) (fi startOffset) flags nullPtr 0
-    if r == retNoMatch
-      then return (Right False)
-      else if r' < 0
-             then wrapRC r
-             else return (Right True)
+    withDataPtr (c_pcre2_match_data_create 1 nullPtr) "wrapTest" $ \dataPtr -> do
+      r@(ReturnCode r') <- c_pcre2_match pcre_ptr cstr (fi len) (fi startOffset) flags dataPtr nullPtr
+      if r == retNoMatch
+        then return (Right False)
+        else if r' < 0
+               then wrapRC r
+               else return (Right True)
 
 -- | Matches a regular expression against a string
 --
 -- Should never return (Right (Just []))
-wrapMatch startOffset (Regex pcre_fptr _ flags) (cstr,len) = do
+wrapMatch startOffset (Regex pcre_fptr _ flags nsub) (cstr,len) = do
  nullTest cstr "wrapMatch cstr" $ do
   withForeignPtr pcre_fptr $ \pcre_ptr -> do
-    nsub <- getNumSubs' pcre_ptr
-    let nsub_int :: Int
-        nsub_int = fi nsub
-        ovec_size :: CInt
-        ovec_size = ((nsub + 1) * 3) -- "man pcreapi" for explanation
-        ovec_bytes :: Int
-        ovec_bytes = (fi ovec_size) * (#const sizeof(int))
-    allocaBytes ovec_bytes $ \ovec -> do
-     nullTest ovec "wrapMatch ovec" $ do
-      r@(ReturnCode r') <- c_pcre_exec pcre_ptr nullPtr cstr (fi len) (fi startOffset) flags ovec ovec_size
+    withDataPtr (c_pcre2_match_data_create_from_pattern pcre_ptr nullPtr) "wrapMatch" $ \dataPtr -> do
+      r@(ReturnCode r') <- c_pcre2_match pcre_ptr cstr (fi len) (fi startOffset) flags dataPtr nullPtr
       if r == retNoMatch
-        then return (Right Nothing)
+        then do
+          return (Right Nothing)
         else if r' < 0
           then wrapRC r
           else do
-            let pairsSet :: Int
-                pairsSet = if r == retNeededMoreSpace -- if r == ReturnCode 0
-                             then nsub_int + 1 -- should not happen
-                             else fi r' -- implies pairsSet > 0
-                extraPairs :: [(Int,Int)]
-                extraPairs = replicate (nsub_int + 1 - pairsSet)
-                                       (unusedOffset,unusedOffset)
-            pairs <- return . toPairs =<< mapM (peekElemOff ovec) [0 .. ((pairsSet*2)-1)]
+            ovecsize <- fi <$> c_pcre2_get_ovector_count dataPtr
+            ovec     <- c_pcre2_get_ovector_pointer dataPtr
+            let extraPairs :: [(Int,Int)]
+                extraPairs = replicate (nsub + 1 - ovecsize) (unusedOffset,unusedOffset)
+            pairs <- return . toPairs =<< mapM (peekElemOff ovec) [0 .. ((ovecsize*2)-1)]
             return . Right . Just $ (pairs ++ extraPairs)
 
 -- | wrapMatchAll is an improvement over wrapMatch since it only
 -- allocates memory with allocaBytes once at the start.
--- 
--- 
-wrapMatchAll (Regex pcre_fptr _ flags) (cstr,len) = do
+wrapMatchAll (Regex pcre_fptr _ flags nsub) (cstr,len) = do
  nullTest cstr "wrapMatchAll cstr" $ do
-  withForeignPtr pcre_fptr $ \regex -> do
-    nsub <- getNumSubs' regex
-    let nsub_int :: Int
-        nsub_int = fi nsub
-        ovec_size :: CInt
-        ovec_size = ((nsub + 1) * 3) -- "man pcreapi" for explanation
-        ovec_bytes :: Int
-        ovec_bytes = (fi ovec_size) * (#const sizeof(int))
-        clen = fi len
-        flags' = (execNotEmpty .|. execAnchored .|. flags)
-    allocaBytes ovec_bytes $ \ovec ->
-     nullTest ovec "wrapMatchAll ovec" $
+  withForeignPtr pcre_fptr $ \pcre_ptr -> do
+    let flags' = (matchNotEmpty .|. matchAnchored .|. flags)
+    withDataPtr (c_pcre2_match_data_create_from_pattern pcre_ptr nullPtr) "wrapMatchAll" $ \dataPtr ->
       let loop acc flags_in_use pos = do
-            r@(ReturnCode r') <- c_pcre_exec regex nullPtr cstr clen (fi pos) flags_in_use ovec ovec_size
+            r@(ReturnCode r') <- c_pcre2_match pcre_ptr cstr (fi len) (fi pos) flags_in_use dataPtr nullPtr
             if r == retNoMatch
               then return (Right (acc []))
               else if r' < 0
                      then wrapRC r
                      else do
-                       let pairsSet = if r == retNeededMoreSpace then nsub_int+1 else fi r'
-                       pairs <- return . toPairs =<< mapM (peekElemOff ovec) [0 .. ((pairsSet*2)-1)]
-                       let acc' = acc . (toMatchArray nsub_int pairs:)
+                       ovecsize <- fi <$> c_pcre2_get_ovector_count dataPtr
+                       ovec     <- c_pcre2_get_ovector_pointer dataPtr
+                       pairs    <- return . toPairs =<< mapM (peekElemOff ovec) [0 .. ((ovecsize*2)-1)]
+                       let acc' = acc . (toMatchArray nsub pairs:)
                        case pairs of
                          [] -> return (Right (acc' []))
-                         ((s,e):_) | s==e -> if s == len 
+                         ((s,e):_) | s==e -> if s == len
                                                then return (Right (acc' []))
                                                else loop acc' flags' e
                                    | otherwise -> loop acc' flags e
@@ -300,23 +322,16 @@ wrapMatchAll (Regex pcre_fptr _ flags) (cstr,len) = do
 toMatchArray :: Int -> [(Int,Int)] -> Array Int (Int,Int)
 toMatchArray n pairs = accumArray (\_ (s,e) -> (s,(e-s))) (-1,0) (0,n) (zip [0..] pairs)
 
-toPairs :: [CInt] -> [(Int,Int)]
+toPairs :: [CSize] -> [(Int,Int)]
 toPairs [] = []
 toPairs (a:b:rest) = (fi a,fi b):toPairs rest
-toPairs [_] = error "Should not have just one element in WrapPCRE.wrapMatchAll.toPairs"
+toPairs [_] = error "Should not have just one element in WrapPCRE.toPairs"
 
-wrapCount (Regex pcre_fptr _ flags) (cstr,len) = do
+wrapCount (Regex pcre_fptr _ flags _) (cstr,len) = do
  nullTest cstr "wrapCount cstr" $ do
   withForeignPtr pcre_fptr $ \pcre_ptr -> do
-    nsub <- getNumSubs' pcre_ptr
-    let ovec_size :: CInt
-        ovec_size = ((nsub + 1) * 3) -- "man pcreapi" for explanation
-        ovec_bytes :: Int
-        ovec_bytes = (fi ovec_size) * (#const sizeof(int))
-        clen = fi len
-    allocaBytes ovec_bytes $ \ovec ->
-     nullTest ovec "wrapCount ovec" $
-      let act pos = c_pcre_exec pcre_ptr nullPtr cstr clen (fi pos) flags ovec ovec_size
+    withDataPtr (c_pcre2_match_data_create_from_pattern pcre_ptr nullPtr) "wrapCount" $ \dataPtr ->
+      let act pos = c_pcre2_match pcre_ptr cstr (fi len) (fi pos) flags dataPtr nullPtr
           loop acc pos | acc `seq` pos `seq` False = undefined
                        | otherwise  = do
             r@(ReturnCode r') <- act pos
@@ -325,6 +340,7 @@ wrapCount (Regex pcre_fptr _ flags) (cstr,len) = do
               else if r' < 0
                 then wrapRC r
                 else do
+                  ovec  <- c_pcre2_get_ovector_pointer dataPtr
                   pairs <- return . toPairs =<< mapM (peekElemOff ovec) [0,1]
                   case pairs of
                     [] -> return (Right (succ acc))
@@ -333,96 +349,121 @@ wrapCount (Regex pcre_fptr _ flags) (cstr,len) = do
       in loop 0 0
 
 getVersion = unsafePerformIO $ do
-  version <- c_pcre_version
-  if version == nullPtr
-    then return (Just "pcre_version was null")
-    else return . Just =<< peekCString version
+  vsize <- c_pcre2_config pcre2ConfigVersion nullPtr
+  allocaBytes vsize $ \v -> do
+    if v == nullPtr
+      then return Nothing
+      else do
+        _ <- c_pcre2_config pcre2ConfigVersion v
+        Just <$> peekCString v
 
-configUTF8 = unsafePerformIO $
-  alloca $ \ptrVal -> do -- (ptrVal :: Ptr CInt)
-    when (ptrVal == nullPtr) (fail "Text.Regex.PCRE.Wrap.configUTF8 could not alloca CInt!!!")
-    _unicodeSupported <- c_pcre_config pcreConfigUtf8 ptrVal
-    {- pcre_config: The  output  is  an  integer that is set to one if UTF-8 support is available; otherwise it is set to zero. -}
-    val <- peek ptrVal
-    case val of
-      (1 :: CInt) -> return True
-      0 -> return False
-      _ -> return False -- should not happen
+configUTF8 = True -- deprecated in v1.0.0.0, UTF8 is always supported by pcre2
 
-foreign import ccall unsafe "pcre.h pcre_compile"
-  c_pcre_compile :: CString -> CompOption -> Ptr CString -> Ptr CInt -> CString -> IO (Ptr PCRE)
-foreign import ccall unsafe "&free"
-  c_ptr_free :: FinalizerPtr a -- FunPtr (Ptr a -> IO ())
-foreign import ccall unsafe "pcre.h pcre_exec"
-  c_pcre_exec :: Ptr PCRE -> Ptr PCRE_Extra -> CString -> CInt -> CInt -> ExecOption -> Ptr CInt -> CInt -> IO ReturnCode
-foreign import ccall unsafe "pcre.h pcre_fullinfo"
-  c_pcre_fullinfo :: Ptr PCRE -> Ptr PCRE_Extra -> InfoWhat -> Ptr a -> IO CInt
-foreign import ccall unsafe "pcre.h pcre_version"
-  c_pcre_version :: IO (Ptr CChar)
-foreign import ccall unsafe "pcre.h pcre_config"
-  c_pcre_config :: ConfigWhat -> Ptr a -> IO CInt
+foreign import ccall unsafe "pcre2.h pcre2_config_8"
+  c_pcre2_config :: ConfigWhat -> Ptr a -> IO Int
+foreign import ccall unsafe "pcre2.h pcre2_compile_8"
+  c_pcre2_compile :: CString -> CSize -> CompOption -> Ptr CInt -> Ptr CSize -> Ptr CompContext -> IO (Ptr PCRE)
+foreign import ccall unsafe "pcre2.h pcre2_get_error_message_8"
+  c_pcre2_get_error_message :: CInt -> CString -> CSize -> IO CInt
+foreign import ccall unsafe "pcre2.h pcre2_pattern_info_8"
+  c_pcre2_pattern_info :: Ptr PCRE -> InfoWhat -> Ptr a -> IO CInt
+foreign import ccall unsafe "pcre2.h &pcre2_code_free_8"
+  c_pcre2_code_free :: FinalizerPtr PCRE
+foreign import ccall unsafe "pcre2.h pcre2_match_data_create_8"
+  c_pcre2_match_data_create :: Word32 -> Ptr MatchContext -> IO (Ptr MatchData)
+foreign import ccall unsafe "pcre2.h pcre2_match_data_create_from_pattern_8"
+  c_pcre2_match_data_create_from_pattern :: Ptr PCRE -> Ptr MatchContext -> IO (Ptr MatchData)
+foreign import ccall unsafe "pcre2.h pcre2_match_8"
+  c_pcre2_match :: Ptr PCRE -> CString -> CSize -> CSize -> MatchOption -> Ptr MatchData -> Ptr MatchContext -> IO ReturnCode
+foreign import ccall unsafe "pcre2.h pcre2_get_ovector_count_8"
+  c_pcre2_get_ovector_count :: Ptr MatchData -> IO Word32
+foreign import ccall unsafe "pcre2.h pcre2_get_ovector_pointer_8"
+  c_pcre2_get_ovector_pointer :: Ptr MatchData -> IO (Ptr CSize)
+foreign import ccall unsafe "pcre2.h pcre2_match_data_free_8"
+  c_pcre2_match_data_free :: Ptr MatchData -> IO ()
 
+-- compExtra :: CompOption
+-- compExtra = CompOption 0 -- no longer needed, pcre2 is always strict in this way
 
 #enum CompOption,CompOption, \
-  compAnchored = PCRE_ANCHORED, \
-  compAutoCallout = PCRE_AUTO_CALLOUT, \
-  compCaseless = PCRE_CASELESS, \
-  compDollarEndOnly = PCRE_DOLLAR_ENDONLY, \
-  compDotAll = PCRE_DOTALL, \
-  compExtended = PCRE_EXTENDED, \
-  compExtra = PCRE_EXTRA, \
-  compFirstLine = PCRE_FIRSTLINE, \
-  compMultiline = PCRE_MULTILINE, \
-  compNoAutoCapture = PCRE_NO_AUTO_CAPTURE, \
-  compUngreedy = PCRE_UNGREEDY, \
-  compUTF8 = PCRE_UTF8, \
-  compNoUTF8Check = PCRE_NO_UTF8_CHECK
+  compAllowEmptyClass = PCRE2_ALLOW_EMPTY_CLASS, \
+  compAltBSUX = PCRE2_ALT_BSUX, \
+  compAltExtendedClass = PCRE2_ALT_EXTENDED_CLASS, \
+  compAltVerbnames = PCRE2_ALT_VERBNAMES, \
+  compAnchored = PCRE2_ANCHORED, \
+  compAutoCallout = PCRE2_AUTO_CALLOUT, \
+  compCaseless = PCRE2_CASELESS, \
+  compDollarEndOnly = PCRE2_DOLLAR_ENDONLY, \
+  compDotAll = PCRE2_DOTALL, \
+  compDupNames = PCRE2_DUPNAMES, \
+  compEndAnchored = PCRE2_ENDANCHORED, \
+  compExtended = PCRE2_EXTENDED, \
+  compExtendedMore = PCRE2_EXTENDED_MORE, \
+  compFirstLine = PCRE2_FIRSTLINE, \
+  compLiteral = PCRE2_LITERAL, \
+  compMatchUnsetBackref = PCRE2_MATCH_UNSET_BACKREF, \
+  compMultiline = PCRE2_MULTILINE, \
+  compNeverBackslashC = PCRE2_NEVER_BACKSLASH_C, \
+  compNoAutoCapture = PCRE2_NO_AUTO_CAPTURE, \
+  compNoAutoPossess = PCRE2_NO_AUTO_POSSESS, \
+  compNoDotstarAnchor = PCRE2_NO_DOTSTAR_ANCHOR, \
+  compNoUTFCheck = PCRE2_NO_UTF_CHECK, \
+  compUngreedy = PCRE2_UNGREEDY, \
+  compUTF = PCRE2_UTF
 
-#enum ExecOption,ExecOption, \
-  execAnchored = PCRE_ANCHORED, \
-  execNotBOL = PCRE_NOTBOL, \
-  execNotEOL = PCRE_NOTEOL, \
-  execNotEmpty = PCRE_NOTEMPTY, \
-  execNoUTF8Check = PCRE_NO_UTF8_CHECK, \
-  execPartial = PCRE_PARTIAL
+#enum MatchOption,MatchOption, \
+  matchAnchored = PCRE2_ANCHORED, \
+  matchCopyMatchedSubject = PCRE2_COPY_MATCHED_SUBJECT, \
+  matchDisableRecurseLoopCheck = PCRE2_DISABLE_RECURSELOOP_CHECK, \
+  matchEndAnchored = PCRE2_ENDANCHORED, \
+  matchNotBOL = PCRE2_NOTBOL, \
+  matchNotEOL = PCRE2_NOTEOL, \
+  matchNotEmpty = PCRE2_NOTEMPTY, \
+  matchNotEmptyAtStart = PCRE2_NOTEMPTY_ATSTART, \
+  matchNoUTFCheck = PCRE2_NO_UTF_CHECK, \
+  matchPartialHard = PCRE2_PARTIAL_HARD, \
+  matchPartialSoft = PCRE2_PARTIAL_SOFT
+
+retUnknownNode :: ReturnCode
+retUnknownNode = ReturnCode minBound -- never returned by pcre2
 
 #enum ReturnCode,ReturnCode, \
-  retNoMatch = PCRE_ERROR_NOMATCH, \
-  retNull = PCRE_ERROR_NULL, \
-  retBadOption = PCRE_ERROR_BADOPTION, \
-  retBadMagic = PCRE_ERROR_BADMAGIC, \
-  retUnknownNode = PCRE_ERROR_UNKNOWN_NODE, \
-  retNoMemory = PCRE_ERROR_NOMEMORY, \
-  retNoSubstring = PCRE_ERROR_NOSUBSTRING
+  retNoMatch = PCRE2_ERROR_NOMATCH, \
+  retPartial = PCRE2_ERROR_PARTIAL, \
+  retNull = PCRE2_ERROR_NULL, \
+  retBadOption = PCRE2_ERROR_BADOPTION, \
+  retBadMagic = PCRE2_ERROR_BADMAGIC, \
+  retNoMemory = PCRE2_ERROR_NOMEMORY, \
+  retNoSubstring = PCRE2_ERROR_NOSUBSTRING
 
 -- Comment out most of these to avoid unused binding warnings
 
--- PCRE_INFO_FIRSTCHAR is deprecated, use PCRE_INFO_FIRSTBYTE instead.
+-- PCRE2_INFO_FIRSTCHAR is deprecated, use PCRE2_INFO_FIRSTBYTE instead.
 #enum InfoWhat,InfoWhat, \
-  PCRE_INFO_CAPTURECOUNT
+  PCRE2_INFO_CAPTURECOUNT
 {-
-  PCRE_INFO_BACKREFMAX, \
-  PCRE_INFO_DEFAULT_TABLES, \
-  PCRE_INFO_FIRSTBYTE, \
-  PCRE_INFO_FIRSTCHAR, \
-  PCRE_INFO_FIRSTTABLE, \
-  PCRE_INFO_LASTLITERAL, \
-  PCRE_INFO_NAMECOUNT, \
-  PCRE_INFO_NAMEENTRYSIZE, \
-  PCRE_INFO_NAMETABLE, \
-  PCRE_INFO_OPTIONS, \
-  PCRE_INFO_SIZE, \
-  PCRE_INFO_STUDYSIZE
+  PCRE2_INFO_BACKREFMAX, \
+  PCRE2_INFO_DEFAULT_TABLES, \
+  PCRE2_INFO_FIRSTBYTE, \
+  PCRE2_INFO_FIRSTCHAR, \
+  PCRE2_INFO_FIRSTTABLE, \
+  PCRE2_INFO_LASTLITERAL, \
+  PCRE2_INFO_NAMECOUNT, \
+  PCRE2_INFO_NAMEENTRYSIZE, \
+  PCRE2_INFO_NAMETABLE, \
+  PCRE2_INFO_OPTIONS, \
+  PCRE2_INFO_SIZE, \
+  PCRE2_INFO_STUDYSIZE
 -}
 #enum ConfigWhat,ConfigWhat, \
-  PCRE_CONFIG_UTF8
+  PCRE2_CONFIG_VERSION
 {-
-  PCRE_CONFIG_UNICODE_PROPERTIES, \
-  PCRE_CONFIG_NEWLINE, \
-  PCRE_CONFIG_LINK_SIZE, \
-  PCRE_CONFIG_POSIX_MALLOC_THRESHOLD, \
-  PCRE_CONFIG_MATCH_LIMIT, \
-  PCRE_CONFIG_MATCH_LIMIT_RECURSION, \
-  PCRE_CONFIG_STACKRECURSE
+  PCRE2_CONFIG_UTF8
+  PCRE2_CONFIG_UNICODE_PROPERTIES, \
+  PCRE2_CONFIG_NEWLINE, \
+  PCRE2_CONFIG_LINK_SIZE, \
+  PCRE2_CONFIG_POSIX_MALLOC_THRESHOLD, \
+  PCRE2_CONFIG_MATCH_LIMIT, \
+  PCRE2_CONFIG_MATCH_LIMIT_RECURSION, \
+  PCRE2_CONFIG_STACKRECURSE
 -}
-

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,41 @@
+module Main where
+
+import Text.Regex.PCRE
+import Test.HUnit
+import qualified Data.ByteString.UTF8 as BSU
+import qualified System.Exit as Exit
+
+test_tester :: Test
+test_tester = TestCase $ assertBool "always True" $ (1 :: Int) == 1
+
+test_version :: Test
+test_version = TestCase $ assertBool "should be a non-empty string"
+  $ maybe False ((>4) . length) getVersion
+
+test_string :: Test
+test_string = TestCase $ assertBool "should match successfully"
+  $ "abcdef" =~ "[abc]+[def]{3}"
+
+test_bytestring :: Test
+test_bytestring = TestCase $ assertBool "should match successfully"
+  $ (BSU.fromString "abbabbbbabbabc") =~ (BSU.fromString "^(abba|bbbb|bc)*$")
+
+emailRegex :: String
+emailRegex = "<([^>@]*)@([a-zA-Z.-]*)>"
+
+test_capture :: Test
+test_capture = TestCase $ assertEqual "should capture correctly"
+  ("abc","<test@example.com>","xyz",["test","example.com"])
+  $ "abc<test@example.com>xyz" =~ emailRegex
+
+tests :: Test
+tests = TestList [ TestLabel "test_tester"           test_tester
+                 , TestLabel "test_version"          test_version
+                 , TestLabel "test_string"           test_string
+                 , TestLabel "test_bytestring"       test_bytestring
+                 , TestLabel "test_capture"          test_capture ]
+
+main :: IO ()
+main = do
+    result <- runTestTT tests
+    if failures result > 0 then Exit.exitFailure else Exit.exitSuccess


### PR DESCRIPTION
Since the old libpcre is now obsolete for some years, migrating to libpcre2 is probably a good idea.  This is a mostly-semantic API change that risks catching some people off guard, hence the major-major version number bump.  I've kept the changes to a minimal set to maintain as much backward-compatibility as possible.

Fixes: #1