### PR TITLE
v0.95.0.1: Drop support for GHC 7, make Prelude imports explicit

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,11 @@
-See also http://pvp.haskell.org/faq
+## 0.95.0.1
+
+_2025-03-02 Andreas Abel_
+
+- Drop support for GHC 7
+- Make `Prelude` imports explicit, add `LANGUAGE NoImplicitPrelude`
+- Make upper bounds of dependencies major-major (all are shipped with GHC)
+- Tested with GHC 8.0 - 9.12.1
 
 ## 0.95.0.0 revision 6
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+[![Hackage version](https://img.shields.io/hackage/v/regex-pcre.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/regex-pcre)
+[![Stackage Nightly](http://stackage.org/package/regex-pcre/badge/nightly)](http://stackage.org/nightly/package/regex-pcre)
+[![Stackage LTS](http://stackage.org/package/regex-pcre/badge/lts)](http://stackage.org/lts/package/regex-pcre)
+[![Haskell-CI](https://github.com/haskell-hvr/regex-pcre/actions/workflows/haskell-ci.yml/badge.svg?branch=master&event=push)](https://github.com/haskell-hvr/regex-pcre/actions/workflows/haskell-ci.yml)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+regex-pcre
+==========
+
+Backend for `regex-base` via binding to PCRE library.
+
+[Documentation](https://hackage.haskell.org/package/regex-pcre/docs/Text-Regex-PCRE.html) on hackage.
+
+Binding to PCRE2 is in [`regex-pcre2`](https://hackage.haskell.org/package/regex-pcre2).

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/regex-pcre.cabal
+++ b/regex-pcre.cabal
@@ -1,7 +1,6 @@
-Cabal-Version:          1.12
+Cabal-Version:          1.24
 Name:                   regex-pcre
-Version:                0.95.0.0
-x-revision:             6
+Version:                0.95.0.1
 
 build-type:             Simple
 license:                BSD3
@@ -19,8 +18,9 @@ description:
   .
   See also <https://wiki.haskell.org/Regular_expressions> for more information.
 
-extra-source-files:
+extra-doc-files:
   ChangeLog.md
+  README.md
 
 tested-with:
   GHC == 9.12.1
@@ -49,7 +49,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/haskell-hvr/regex-pcre.git
-  tag:      v0.95.0.0-r6
+  tag:      v0.95.0.1
 
 library
   hs-source-dirs: src
@@ -64,8 +64,10 @@ library
   other-modules:
       Paths_regex_pcre
 
-  default-language: Haskell2010
+  default-language:
+      Haskell2010
   default-extensions:
+      NoImplicitPrelude
       MultiParamTypeClasses
       FunctionalDependencies
       ForeignFunctionInterface
@@ -75,14 +77,12 @@ library
       TypeSynonymInstances
       FlexibleInstances
 
-  build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 5
-               , containers >= 0.4 && < 0.8
-               , bytestring >= 0.9 && < 0.13
-               , array      >= 0.3 && < 0.6
-
-  if !impl(ghc >= 8)
-      build-depends: fail == 4.9.*
+  build-depends:
+        regex-base == 0.94.*
+      , base       >= 4.9  && < 5
+      , containers >= 0.5  && < 1
+      , bytestring >= 0.10 && < 1
+      , array      >= 0.5  && < 1
 
   if flag(pkg-config)
     pkgconfig-depends: libpcre
@@ -90,6 +90,5 @@ library
     extra-libraries: pcre
 
   ghc-options:
-    -O2
-    -Wall -fno-warn-unused-imports
-    -- -Wcompat -- options cannot be changed in a revision
+    -Wall
+    -Wcompat

--- a/src/Text/Regex/PCRE.hs
+++ b/src/Text/Regex/PCRE.hs
@@ -30,7 +30,7 @@ module Text.Regex.PCRE(getVersion_Text_Regex_PCRE
   -- ** Wrap, for '=~' and '=~~', types and constants
   ,module Text.Regex.PCRE.Wrap) where
 
-import Prelude hiding (fail)
+import Prelude ()
 
 import Text.Regex.PCRE.Wrap(Regex, CompOption(CompOption), ExecOption(ExecOption), (=~), (=~~),
   unusedOffset, getNumSubs, configUTF8, getVersion,
@@ -44,7 +44,7 @@ import Text.Regex.PCRE.String()
 import Text.Regex.PCRE.Sequence()
 import Text.Regex.PCRE.ByteString()
 import Text.Regex.PCRE.ByteString.Lazy()
-import Data.Version(Version(..))
+import Data.Version(Version)
 import Text.Regex.Base
 import qualified Paths_regex_pcre
 

--- a/src/Text/Regex/PCRE/ByteString.hs
+++ b/src/Text/Regex/PCRE/ByteString.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 {-|
 This exports instances of the high level API and the medium level
 API of 'compile','execute', and 'regexec'.
@@ -45,7 +45,16 @@ module Text.Regex.PCRE.ByteString(
   execPartial
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Either(Left,Right), either
+  , Int, (-), fromIntegral, pred
+  , IO, (>>=), return
+  , Maybe(Nothing,Just)
+  , Show(show)
+  , String
+  , ($), (.), (==), (&&), otherwise, not
+  , (++), map, length
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Text.Regex.PCRE.Wrap -- all

--- a/src/Text/Regex/PCRE/ByteString/Lazy.hs
+++ b/src/Text/Regex/PCRE/ByteString/Lazy.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 {-|
 This exports instances of the high level API and the medium level
 API of 'compile','execute', and 'regexec'.
@@ -45,7 +46,16 @@ module Text.Regex.PCRE.ByteString.Lazy(
   execPartial
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Either(Left,Right), either
+  , Int
+  , IO, (>>=), return
+  , Maybe(Nothing,Just)
+  , Show(show)
+  , String
+  , ($), (.), (==), (&&), otherwise, not
+  , (++), map
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Text.Regex.PCRE.Wrap -- all

--- a/src/Text/Regex/PCRE/String.hs
+++ b/src/Text/Regex/PCRE/String.hs
@@ -45,7 +45,16 @@ module Text.Regex.PCRE.String(
   execPartial
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Either(Left,Right), either
+  , Int, (-), fromIntegral, pred
+  , IO, (>>=), return
+  , Maybe(Nothing,Just)
+  , Show(show)
+  , String
+  , ($), (.), (==), otherwise
+  , (++), drop, length, map, take
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Text.Regex.PCRE.Wrap -- all
@@ -74,9 +83,9 @@ instance RegexLike Regex String where
     withCStringLen str (wrapTest 0 regex) >>= unwrap
   matchOnce regex str = unsafePerformIO $
     execute regex str >>= unwrap
-  matchAll regex str = unsafePerformIO $ 
+  matchAll regex str = unsafePerformIO $
     withCStringLen str (wrapMatchAll regex) >>= unwrap
-  matchCount regex str = unsafePerformIO $ 
+  matchCount regex str = unsafePerformIO $
     withCStringLen str (wrapCount regex) >>= unwrap
 
 -- | Compiles a regular expression
@@ -98,7 +107,7 @@ execute regex str = do
   case maybeStartEnd of
     Right Nothing -> return (Right Nothing)
 --  Right (Just []) -> fail "got [] back!" -- should never happen
-    Right (Just parts) -> 
+    Right (Just parts) ->
       return . Right . Just . listArray (0,pred (length parts))
       . map (\(s,e)->(fromIntegral s, fromIntegral (e-s))) $ parts
     Left err -> return (Left err)
@@ -113,7 +122,7 @@ regexec regex str = do
   let getSub (start,stop) | start == unusedOffset = ""
                           | otherwise = take (stop-start) . drop start $ str
       matchedParts [] = ("","",str,[]) -- no information
-      matchedParts (matchedStartStop@(start,stop):subStartStop) = 
+      matchedParts (matchedStartStop@(start,stop):subStartStop) =
         (take start str
         ,getSub matchedStartStop
         ,drop stop str

--- a/src/Text/Regex/PCRE/Wrap.hsc
+++ b/src/Text/Regex/PCRE/Wrap.hsc
@@ -69,23 +69,31 @@ module Text.Regex.PCRE.Wrap(
   retNoSubstring
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Bool(False,True)
+  , Either(Left,Right)
+  , Eq, (==), (/=), (<)
+  , IO, (=<<), return
+  , Integral, Int, (*), (-), fromIntegral, succ
+  , Maybe(Nothing,Just)
+  , Num((+))
+  , Show(show)
+  , String
+  , ($), (.), id, error, seq, undefined, otherwise
+  , (++), mapM, replicate, zip
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Control.Monad(when)
 import Data.Array(Array,accumArray)
-import Data.Bits(Bits((.|.))) -- ((.&.),(.|.),complement))
+import Data.Bits(Bits((.|.)))
 import System.IO.Unsafe(unsafePerformIO)
-import Foreign(Ptr,ForeignPtr,FinalizerPtr -- ,FunPtr
+import Foreign(Ptr,ForeignPtr,FinalizerPtr
               ,alloca,allocaBytes,nullPtr
               ,peek,peekElemOff
               ,newForeignPtr,withForeignPtr)
 import Foreign.C(CChar)
-#if __GLASGOW_HASKELL__ >= 703
 import Foreign.C(CInt(CInt))
-#else
-import Foreign.C(CInt)
-#endif
 import Foreign.C.String(CString,CStringLen,peekCString)
 import Text.Regex.Base.RegexLike(RegexOptions(..),RegexMaker(..),RegexContext(..),MatchArray,MatchOffset)
 
@@ -181,14 +189,14 @@ nullTest' :: Ptr a -> String -> IO (Either (MatchOffset,String) b) -> IO (Either
 {-# INLINE nullTest' #-}
 nullTest' ptr msg io = do
   if nullPtr == ptr
-    then return (Left (0,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg)) 
+    then return (Left (0,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg))
     else io
 
 nullTest :: Ptr a -> String -> IO (Either WrapError b) -> IO (Either WrapError b)
 {-# INLINE nullTest #-}
 nullTest ptr msg io = do
   if nullPtr == ptr
-    then return (Left (retOk,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg)) 
+    then return (Left (retOk,"Ptr parameter was nullPtr in Text.Regex.PCRE.Wrap."++msg))
     else io
 
 wrapRC :: ReturnCode -> IO (Either WrapError b)
@@ -264,8 +272,8 @@ wrapMatch startOffset (Regex pcre_fptr _ flags) (cstr,len) = do
 
 -- | wrapMatchAll is an improvement over wrapMatch since it only
 -- allocates memory with allocaBytes once at the start.
--- 
--- 
+--
+--
 wrapMatchAll (Regex pcre_fptr _ flags) (cstr,len) = do
  nullTest cstr "wrapMatchAll cstr" $ do
   withForeignPtr pcre_fptr $ \regex -> do
@@ -292,7 +300,7 @@ wrapMatchAll (Regex pcre_fptr _ flags) (cstr,len) = do
                        let acc' = acc . (toMatchArray nsub_int pairs:)
                        case pairs of
                          [] -> return (Right (acc' []))
-                         ((s,e):_) | s==e -> if s == len 
+                         ((s,e):_) | s==e -> if s == len
                                                then return (Right (acc' []))
                                                else loop acc' flags' e
                                    | otherwise -> loop acc' flags e


### PR DESCRIPTION
Harden the implementation against ecosystem changes by making the Prelude imports explicit.
Since there are no practical means to test this against GHC < 8, we drop support for GHC 7 explicitly, bumping to base >= 4.9.
All dependencies of regex-base ship with GHC, so maintaining precise upper bounds is just busy-work. Thus, we make upper-bounds major-major, so we just get the very strong signals of drastic API changes. Usual API changes should not affect this very stable package.

